### PR TITLE
fix(plugins): use new pylint api

### DIFF
--- a/flakeheaven/_logic/_discover.py
+++ b/flakeheaven/_logic/_discover.py
@@ -47,26 +47,6 @@ def get_installed(app) -> Iterator[Dict[str, Any]]:
                 raise ValueError('Invalid code format: {}'.format(code))
             plugins_codes[key].append(code)
 
-    plugins = getattr(app.formatting_plugins, 'plugins')
-    for plugin_name in plugins:
-        if plugin_name != 'pylint':
-            continue
-        key = ('formatting_plugins', plugin_name)
-        plugin = plugins[plugin_name]
-        versions[key[-1]] = plugin._version
-
-        # if codes for plugin specified explicitly in ALIASES, use it
-        codes = ALIASES.get(plugin_name, [])
-        if codes:
-            plugins_codes[key] = list(codes)
-            continue
-
-        # otherwise get codes from plugin entrypoint
-        code = plugin_name
-        if not REX_CODE.match(code):
-            raise ValueError('Invalid code format: {}'.format(code))
-        plugins_codes[key].append(code)
-
     if 'flake8-docstrings' in versions:
         versions['flake8-docstrings'] = versions['flake8-docstrings'].split(',')[0]
 

--- a/flakeheaven/plugins/_pylint.py
+++ b/flakeheaven/plugins/_pylint.py
@@ -6,7 +6,7 @@ from typing import Sequence
 
 try:
     # external
-    from pylint.__pkginfo__ import version
+    from pylint.__pkginfo__ import __version__ as version
     from pylint.lint import Run
     from pylint.reporters import BaseReporter
 except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ dev = [
     "wemake-python-styleguide",
     "mypy",
     "pytest",
-    "isort[pyproject]",
+    "isort",
 ]
 
 [build-system]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,6 +70,15 @@ def test_version(capsys):
     assert 'Flake8' in captured.out
 
 
+def test_plugins(capsys):
+    result = main(['plugins'])
+    assert result == (0, '')
+    captured = capsys.readouterr()
+    assert captured.err == ''
+    assert 'NAME' in captured.out
+    assert 'RULES' in captured.out
+
+
 @patch('sys.argv', ['flakeheaven'])
 def test_lint_help(capsys):
     result = main(['lint', '--help'])


### PR DESCRIPTION
pylint started using `__version__` instead of `version` somewhen, which broke flakehells compatibility