### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"


### PR DESCRIPTION
This PR adds a configuration file to enable dependabot for this repository

Reference: https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates

Dependabot will help keep the poetry dependency specification file up to date with the latest packages out there, aside from reducing tech debt, this will notify the project maintainers of any plugin updates that are compatible or incompatible with flakeheaven. 