### PR TITLE
Use relative path

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -67,6 +67,7 @@ max_line_length=90
 FlakeHeaven provides a few additional options that aren't supported by the original flake8. They can be specified as everything else, in config or as CLI flags.
 
 + `--baseline` -- path to [baseline](commands/baseline) file.
++ `--relative` -- Treat file paths as relative to directory containing baseline file.
 + `--safe` -- suppress exceptions from plugins. In that case, the exception will be converted into `E902` error.
 
 ## Ignored options

--- a/flakeheaven/_logic/_baseline.py
+++ b/flakeheaven/_logic/_baseline.py
@@ -3,9 +3,9 @@ from hashlib import md5
 from pathlib import Path
 
 
-def make_baseline(path: str, context: str, code: str, line: int) -> str:
+def make_baseline(path: Path, context: str, code: str, line: int) -> str:
     digest = md5()
-    digest.update(Path(path).as_posix().lstrip('./').encode())
+    digest.update(path.as_posix().lstrip('./').encode())
     digest.update((context or str(line)).strip().encode())
     digest.update(code.encode())
     return digest.hexdigest()

--- a/flakeheaven/_patched/_app.py
+++ b/flakeheaven/_patched/_app.py
@@ -54,6 +54,7 @@ class FlakeHeavenApplication(Application):
         """
         group = manager.parser.add_argument_group('FlakeHeaven')
         group.add_argument('--baseline', help='path to baseline')
+        group.add_argument('--relative', action='store_true', help='Treat file paths as relative to directory containing baseline file')
         group.add_argument('--safe', action='store_true', help='suppress exceptions from plugins')
         self._option_manager = manager
 
@@ -156,6 +157,7 @@ class FlakeHeavenApplication(Application):
             style_guide=self.guide,
             arguments=self.args,
             checker_plugins=self.check_plugins,
+            relative=self.options.relative,
         )
 
     def find_plugins(self, config_finder) -> None:

--- a/flakeheaven/_patched/_app.py
+++ b/flakeheaven/_patched/_app.py
@@ -54,7 +54,8 @@ class FlakeHeavenApplication(Application):
         """
         group = manager.parser.add_argument_group('FlakeHeaven')
         group.add_argument('--baseline', help='path to baseline')
-        group.add_argument('--relative', action='store_true', help='Treat file paths as relative to directory containing baseline file')
+        group.add_argument('--relative', action='store_true',
+                           help='Treat file paths as relative to directory containing baseline file')
         group.add_argument('--safe', action='store_true', help='suppress exceptions from plugins')
         self._option_manager = manager
 

--- a/flakeheaven/_patched/_checkers.py
+++ b/flakeheaven/_patched/_checkers.py
@@ -26,6 +26,7 @@ class Result(NamedTuple):
     text: str
     line: str
 
+
 def is_relative_to(path: Path, maybe_parent: Path):
     try:
         path.relative_to(maybe_parent)
@@ -34,6 +35,7 @@ def is_relative_to(path: Path, maybe_parent: Path):
     else:
         return True
 
+
 class FlakeHeavenCheckersManager(Manager):
     """
     Patched flake8.checker.Manager to provide `plugins` support
@@ -41,7 +43,7 @@ class FlakeHeavenCheckersManager(Manager):
 
     def __init__(self, baseline: Optional[str], **kwargs):
         self.baseline = set()
-        self.relative = kwargs.pop("relative", False)
+        self.relative = kwargs.pop('relative', False)
         if baseline:
             with open(baseline) as stream:
                 self.baseline = {line.strip() for line in stream}

--- a/flakeheaven/_patched/_checkers.py
+++ b/flakeheaven/_patched/_checkers.py
@@ -233,8 +233,11 @@ class FlakeHeavenCheckersManager(Manager):
 
             # skip baselined errors
             if self.baseline:
+                _path = Path(filename)
+                if _path.is_relative_to(self.root_path):
+                    _path = _path.relative_to(self.root_path)
                 digest = make_baseline(
-                    path=Path(filename).relative_to(self.root_path),
+                    path=_path,
                     context=result.line,
                     code=result.error_code,
                     line=result.line_number,

--- a/flakeheaven/_patched/_checkers.py
+++ b/flakeheaven/_patched/_checkers.py
@@ -26,6 +26,13 @@ class Result(NamedTuple):
     text: str
     line: str
 
+def is_relative_to(path: Path, maybe_parent: Path):
+    try:
+        path.relative_to(maybe_parent)
+    except ValueError:
+        return False
+    else:
+        return True
 
 class FlakeHeavenCheckersManager(Manager):
     """
@@ -235,7 +242,7 @@ class FlakeHeavenCheckersManager(Manager):
             # skip baselined errors
             if self.baseline:
                 _path = Path(filename)
-                if self.relative and _path.is_relative_to(self.root_path):
+                if self.relative and is_relative_to(_path, self.root_path):
                     _path = _path.relative_to(self.root_path)
                 digest = make_baseline(
                     path=_path,

--- a/flakeheaven/_patched/_checkers.py
+++ b/flakeheaven/_patched/_checkers.py
@@ -34,6 +34,7 @@ class FlakeHeavenCheckersManager(Manager):
 
     def __init__(self, baseline: Optional[str], **kwargs):
         self.baseline = set()
+        self.relative = kwargs.pop("relative", False)
         if baseline:
             with open(baseline) as stream:
                 self.baseline = {line.strip() for line in stream}
@@ -234,7 +235,7 @@ class FlakeHeavenCheckersManager(Manager):
             # skip baselined errors
             if self.baseline:
                 _path = Path(filename)
-                if _path.is_relative_to(self.root_path):
+                if self.relative and _path.is_relative_to(self.root_path):
                     _path = _path.relative_to(self.root_path)
                 digest = make_baseline(
                     path=_path,

--- a/flakeheaven/_patched/_checkers.py
+++ b/flakeheaven/_patched/_checkers.py
@@ -37,6 +37,7 @@ class FlakeHeavenCheckersManager(Manager):
         if baseline:
             with open(baseline) as stream:
                 self.baseline = {line.strip() for line in stream}
+            self.root_path = Path(baseline).resolve().parent
         super().__init__(**kwargs)
 
     def make_checkers(self, paths: List[str] = None) -> None:
@@ -233,7 +234,7 @@ class FlakeHeavenCheckersManager(Manager):
             # skip baselined errors
             if self.baseline:
                 digest = make_baseline(
-                    path=filename,
+                    path=Path(filename).relative_to(self.root_path),
                     context=result.line,
                     code=result.error_code,
                     line=result.line_number,

--- a/flakeheaven/formatters/_baseline.py
+++ b/flakeheaven/formatters/_baseline.py
@@ -1,3 +1,4 @@
+# built-in
 from pathlib import Path
 
 # external

--- a/flakeheaven/formatters/_baseline.py
+++ b/flakeheaven/formatters/_baseline.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 # external
 from flake8.formatting.base import BaseFormatter
 
@@ -9,7 +11,7 @@ class BaseLineFormatter(BaseFormatter):
     def format(self, error):
         filename = error.filename
         return make_baseline(
-            path=filename,
+            path=Path(filename),
             code=error.code,
             line=error.line_number,
             context=error.physical_line,

--- a/flakeheaven/formatters/_gitlab.py
+++ b/flakeheaven/formatters/_gitlab.py
@@ -1,5 +1,6 @@
 # built-in
 import json
+from pathlib import Path
 
 # external
 from flake8.formatting.base import BaseFormatter
@@ -29,7 +30,7 @@ class GitlabFormatter(BaseFormatter):
     def format(self, error):
         filename = error.filename
         digest = make_baseline(
-            path=filename,
+            path=Path(filename),
             code=error.code,
             line=error.line_number,
             context=error.physical_line,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -205,12 +205,16 @@ def test_exceptions_stdin(capsys, tmp_path: Path):
     assert captured.out.strip() == "example.py:2:1: F821 undefined name 'a'"
 
 
+@pytest.mark.parametrize('relative', [True, False])
 @patch('sys.argv', ['flakeheaven'])
-def test_baseline(capsys, tmp_path: Path):
+def test_baseline(capsys, tmp_path: Path, relative: bool):
     code_path = tmp_path / 'example.py'
     code_path.write_text('a\nb\n')
     with chdir(tmp_path):
-        result = main(['baseline', str(code_path.relative_to(tmp_path))])
+        result = main([
+            'baseline',
+            str(code_path.relative_to(tmp_path)) if relative else str(code_path),
+        ])
     assert result == (0, '')
     captured = capsys.readouterr()
     assert captured.err == ''
@@ -220,12 +224,15 @@ def test_baseline(capsys, tmp_path: Path):
     line_path = tmp_path / 'baseline.txt'
     line_path.write_text(hashes[0])
     with chdir(tmp_path):
-        result = main([
+        args = [
             'lint',
             '--baseline', str(line_path),
             '--format', 'default',
             str(code_path),
-        ])
+        ]
+        if relative:
+            args.insert(-1, '--relative')
+        result = main(args)
     assert result == (1, '')
     captured = capsys.readouterr()
     assert captured.err == ''

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -210,7 +210,7 @@ def test_baseline(capsys, tmp_path: Path):
     code_path = tmp_path / 'example.py'
     code_path.write_text('a\nb\n')
     with chdir(tmp_path):
-        result = main(['baseline', str(code_path)])
+        result = main(['baseline', str(code_path.relative_to(tmp_path))])
     assert result == (0, '')
     captured = capsys.readouterr()
     assert captured.err == ''


### PR DESCRIPTION
Fix for #38 

Add option to for treating paths in command line as relative to baseline file path, even when given as absolute path.