### PR TITLE
fix(plugins): increase max violation code length

### DIFF
--- a/flakeheaven/_logic/_discover.py
+++ b/flakeheaven/_logic/_discover.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Iterable, Iterator
 from ._plugin import get_plugin_name
 
 
-REX_CODE = re.compile(r'^[A-Z]{1,5}[0-9]{0,5}$')
+REX_CODE = re.compile(r'^[A-Z]{1,9}[0-9]{0,5}$')
 
 ALIASES = {
     'flake-mutable': ('M511', ),


### PR DESCRIPTION
There is at least one plugin out there whose code length is longer than 5 - having one or more of those plugins configured would trigger a crash when enumerating plugins or looking codes up.

Fixes #54.