### PR TITLE
fix(formatters): use another plugin name colour

### DIFF
--- a/flakeheaven/formatters/_colored.py
+++ b/flakeheaven/formatters/_colored.py
@@ -38,7 +38,7 @@ class ColoredFormatter(Default):
         )
         plugin = getattr(error, 'plugin', None)
         if plugin:
-            line += colored(' [{}]'.format(plugin), 'grey')
+            line += colored(' [{}]'.format(plugin), 'magenta')
         return line
 
     def show_source(self, error: Violation) -> str:

--- a/flakeheaven/formatters/_grouped.py
+++ b/flakeheaven/formatters/_grouped.py
@@ -43,7 +43,7 @@ class GroupedFormatter(ColoredFormatter):
         )
         plugin = getattr(error, 'plugin', None)
         if plugin:
-            line += colored(' [{}]'.format(plugin), 'grey')
+            line += colored(' [{}]'.format(plugin), 'magenta')
         return line
 
     def show_statistics(self, statistics: Statistics) -> None:


### PR DESCRIPTION
Violations' source plugin was printed in black, which doesn't really work that well with dark terminal backgrounds.  Using magenta instead of black should work on both dark and light terminal backgrounds.

Fixes #57.