### PR TITLE
perf(import): Import urllib3 only if needed

### DIFF
--- a/flakeheaven/_logic/_config.py
+++ b/flakeheaven/_logic/_config.py
@@ -28,7 +28,7 @@ def _read_local(path: Path) -> Dict[str, Any]:
 
 
 def _read_remote(url: str) -> Dict[str, Any]:
-    import urllib3
+    import urllib3  # isort: skip
     http = urllib3.PoolManager()
     response = http.request('GET', url)
     return _parse_config(response.data.decode())

--- a/flakeheaven/_logic/_config.py
+++ b/flakeheaven/_logic/_config.py
@@ -4,7 +4,6 @@ from typing import Any, Dict
 
 # external
 import toml
-import urllib3
 from flake8.utils import normalize_paths
 
 
@@ -29,6 +28,7 @@ def _read_local(path: Path) -> Dict[str, Any]:
 
 
 def _read_remote(url: str) -> Dict[str, Any]:
+    import urllib3
     http = urllib3.PoolManager()
     response = http.request('GET', url)
     return _parse_config(response.data.decode())


### PR DESCRIPTION
This speeds up `flakeheaven --help` by almost 1/3 (~30ms) on my machine.

<img width="555" alt="image" src="https://user-images.githubusercontent.com/36469655/167669142-baa414ff-bb53-42f7-90e1-68e6b467a3e2.png">
<details>
  <summary>Full pyinstrument output</summary>
  
```py
  _     ._   __/__   _ _  _  _ _/_   Recorded: 08:38:00  Samples:  95
 /_//_/// /_\ / //_// / //_'/ //     Duration: 0.099     CPU time: 0.073
/   _/                      v4.1.1

Program: flakeheaven --help --show-all

0.099 <module>  <string>:1
└─ 0.099 run_module  runpy.py:199
   └─ 0.099 _get_module_details  runpy.py:103
      └─ 0.099 _get_module_details  runpy.py:103
         └─ 0.099 <module>  flakeheaven/__init__.py:1
            ├─ 0.098 <module>  flakeheaven/_cli.py:1
            │  ├─ 0.053 <module>  flakeheaven/_logic/__init__.py:1
            │  │  ├─ 0.035 <module>  flakeheaven/_logic/_config.py:1
            │  │  │  ├─ 0.028 <module>  urllib3/__init__.py:1
            │  │  │  │  ├─ 0.017 <module>  urllib3/connectionpool.py:1
            │  │  │  │  │  ├─ 0.013 <module>  urllib3/connection.py:1
            │  │  │  │  │  │  ├─ 0.012 <module>  urllib3/util/__init__.py:1
            │  │  │  │  │  │  │  ├─ 0.011 <module>  urllib3/util/ssl_.py:1
            │  │  │  │  │  │  │  │  ├─ 0.009 <module>  urllib3/util/url.py:1
            │  │  │  │  │  │  │  │  │  └─ 0.009 compile  re.py:249
            │  │  │  │  │  │  │  │  │     └─ 0.009 _compile  re.py:288
            │  │  │  │  │  │  │  │  │        └─ 0.009 compile  sre_compile.py:759
            │  │  │  │  │  │  │  │  │           ├─ 0.006 parse  sre_parse.py:937
            │  │  │  │  │  │  │  │  │           │  ├─ 0.005 _parse_sub  sre_parse.py:435
            │  │  │  │  │  │  │  │  │           │  │  └─ 0.005 _parse  sre_parse.py:493
            │  │  │  │  │  │  │  │  │           │  │     └─ 0.005 _parse_sub  sre_parse.py:435
            │  │  │  │  │  │  │  │  │           │  │        └─ 0.005 _parse  sre_parse.py:493
            │  │  │  │  │  │  │  │  │           │  │           ├─ 0.004 _parse_sub  sre_parse.py:435
            │  │  │  │  │  │  │  │  │           │  │           │  └─ 0.004 _parse  sre_parse.py:493
            │  │  │  │  │  │  │  │  │           │  │           │     ├─ 0.001 __getitem__  sre_parse.py:164
            │  │  │  │  │  │  │  │  │           │  │           │     ├─ 0.001 [self]
            │  │  │  │  │  │  │  │  │           │  │           │     ├─ 0.001 _parse_sub  sre_parse.py:435
            │  │  │  │  │  │  │  │  │           │  │           │     │  └─ 0.001 _parse  sre_parse.py:493
            │  │  │  │  │  │  │  │  │           │  │           │     └─ 0.001 __len__  sre_parse.py:160
            │  │  │  │  │  │  │  │  │           │  │           └─ 0.001 get  sre_parse.py:254
            │  │  │  │  │  │  │  │  │           │  │              └─ 0.001 __next  sre_parse.py:233
            │  │  │  │  │  │  │  │  │           │  └─ 0.001 [self]
            │  │  │  │  │  │  │  │  │           └─ 0.003 _code  sre_compile.py:598
            │  │  │  │  │  │  │  │  │              └─ 0.003 _compile  sre_compile.py:71
            │  │  │  │  │  │  │  │  │                 └─ 0.003 _compile  sre_compile.py:71
            │  │  │  │  │  │  │  │  │                    └─ 0.003 _compile  sre_compile.py:71
            │  │  │  │  │  │  │  │  │                       └─ 0.003 _compile  sre_compile.py:71
            │  │  │  │  │  │  │  │  │                          ├─ 0.001 _optimize_charset  sre_compile.py:276
            │  │  │  │  │  │  │  │  │                          ├─ 0.001 [self]
            │  │  │  │  │  │  │  │  │                          └─ 0.001 _simple  sre_compile.py:423
            │  │  │  │  │  │  │  │  │                             └─ 0.001 __len__  sre_parse.py:160
            │  │  │  │  │  │  │  │  ├─ 0.001 BufferedReader.read  <built-in>:0
            │  │  │  │  │  │  │  │  └─ 0.001 stat  <built-in>:0
            │  │  │  │  │  │  │  └─ 0.001 <module>  urllib3/util/connection.py:1
            │  │  │  │  │  │  │     └─ 0.001 BufferedReader.read  <built-in>:0
            │  │  │  │  │  │  └─ 0.001 <module>  urllib3/util/ssl_match_hostname.py:1
            │  │  │  │  │  │     └─ 0.001 loads  <built-in>:0
            │  │  │  │  │  ├─ 0.001 __get__  urllib3/packages/six.py:95
            │  │  │  │  │  │  └─ 0.001 _resolve  urllib3/packages/six.py:117
            │  │  │  │  │  │     └─ 0.001 _import_module  urllib3/packages/six.py:85
            │  │  │  │  │  │        └─ 0.001 BufferedReader.read  <built-in>:0
            │  │  │  │  │  ├─ 0.001 BufferedReader.read  <built-in>:0
            │  │  │  │  │  ├─ 0.001 loads  <built-in>:0
            │  │  │  │  │  └─ 0.001 <module>  urllib3/request.py:1
            │  │  │  │  ├─ 0.007 <module>  urllib3/exceptions.py:1
            │  │  │  │  │  ├─ 0.005 find_spec  urllib3/packages/six.py:190
            │  │  │  │  │  │  └─ 0.005 is_package  urllib3/packages/six.py:215
            │  │  │  │  │  │     └─ 0.005 __getattr__  urllib3/packages/six.py:120
            │  │  │  │  │  │        └─ 0.005 _resolve  urllib3/packages/six.py:117
            │  │  │  │  │  │           └─ 0.005 _import_module  urllib3/packages/six.py:85
            │  │  │  │  │  │              ├─ 0.003 <module>  http/client.py:1
            │  │  │  │  │  │              │  ├─ 0.002 <module>  ssl.py:1
            │  │  │  │  │  │              │  │  ├─ 0.001 _TLSAlertType  ssl.py:182
            │  │  │  │  │  │              │  │  │  └─ 0.001 __setitem__  enum.py:89
            │  │  │  │  │  │              │  │  │     └─ 0.001 _is_sunder  enum.py:33
            │  │  │  │  │  │              │  │  └─ 0.001 _convert_  enum.py:536
            │  │  │  │  │  │              │  │     └─ 0.001 __call__  enum.py:359
            │  │  │  │  │  │              │  │        └─ 0.001 _create_  enum.py:483
            │  │  │  │  │  │              │  │           └─ 0.001 __new__  enum.py:180
            │  │  │  │  │  │              │  │              └─ 0.001 <setcomp>  enum.py:222
            │  │  │  │  │  │              │  │                 └─ 0.001 isinstance  <built-in>:0
            │  │  │  │  │  │              │  └─ 0.001 loads  <built-in>:0
            │  │  │  │  │  │              └─ 0.001 listdir  <built-in>:0
            │  │  │  │  │  ├─ 0.001 BufferedReader.read  <built-in>:0
            │  │  │  │  │  └─ 0.001 __build_class__  <built-in>:0
            │  │  │  │  ├─ 0.001 listdir  <built-in>:0
            │  │  │  │  ├─ 0.001 BufferedReader.read  <built-in>:0
            │  │  │  │  └─ 0.001 <module>  logging/__init__.py:1
            │  │  │  │     └─ 0.001 PercentStyle  logging/__init__.py:412
            │  │  │  │        └─ 0.001 compile  re.py:249
            │  │  │  │           └─ 0.001 _compile  re.py:288
            │  │  │  │              └─ 0.001 compile  sre_compile.py:759
            │  │  │  │                 └─ 0.001 _code  sre_compile.py:598
            │  │  │  │                    └─ 0.001 _compile  sre_compile.py:71
            │  │  │  │                       └─ 0.001 _optimize_charset  sre_compile.py:276
            │  │  │  ├─ 0.003 <module>  toml/__init__.py:1
            │  │  │  │  ├─ 0.002 <module>  toml/encoder.py:1
            │  │  │  │  │  ├─ 0.001 <module>  decimal.py:1
            │  │  │  │  │  │  └─ 0.001 <module>  numbers.py:1
            │  │  │  │  │  │     └─ 0.001 Real  numbers.py:147
            │  │  │  │  │  └─ 0.001 <module>  toml/decoder.py:1
            │  │  │  │  │     └─ 0.001 compile  re.py:249
            │  │  │  │  │        └─ 0.001 _compile  re.py:288
            │  │  │  │  │           └─ 0.001 compile  sre_compile.py:759
            │  │  │  │  │              └─ 0.001 parse  sre_parse.py:937
            │  │  │  │  │                 └─ 0.001 _parse_sub  sre_parse.py:435
            │  │  │  │  │                    └─ 0.001 _parse  sre_parse.py:493
            │  │  │  │  │                       └─ 0.001 _parse_sub  sre_parse.py:435
            │  │  │  │  │                          └─ 0.001 _parse  sre_parse.py:493
            │  │  │  │  │                             └─ 0.001 __getitem__  sre_parse.py:164
            │  │  │  │  └─ 0.001 BufferedReader.read  <built-in>:0
            │  │  │  └─ 0.003 <module>  flake8/utils.py:1
            │  │  │     ├─ 0.002 <module>  platform.py:1
            │  │  │     │  └─ 0.002 compile  re.py:249
            │  │  │     │     └─ 0.002 _compile  re.py:288
            │  │  │     │        ├─ 0.001 compile  sre_compile.py:759
            │  │  │     │        │  └─ 0.001 _code  sre_compile.py:598
            │  │  │     │        │     └─ 0.001 _compile  sre_compile.py:71
            │  │  │     │        │        └─ 0.001 _compile  sre_compile.py:71
            │  │  │     │        │           └─ 0.001 _compile  sre_compile.py:71
            │  │  │     │        │              └─ 0.001 _compile  sre_compile.py:71
            │  │  │     │        │                 └─ 0.001 _optimize_charset  sre_compile.py:276
            │  │  │     │        └─ 0.001 isstring  sre_compile.py:595
            │  │  │     └─ 0.001 BufferedReader.read  <built-in>:0
            │  │  ├─ 0.008 <module>  flakeheaven/_logic/_snapshot.py:1
            │  │  │  ├─ 0.007 <module>  flake8/checker.py:1
            │  │  │  │  ├─ 0.003 <module>  multiprocessing/__init__.py:1
            │  │  │  │  │  └─ 0.003 <module>  multiprocessing/context.py:1
            │  │  │  │  │     ├─ 0.001 <module>  multiprocessing/process.py:1
            │  │  │  │  │     ├─ 0.001 <module>  multiprocessing/reduction.py:1
            │  │  │  │  │     │  └─ 0.001 <module>  pickle.py:1
            │  │  │  │  │     │     └─ 0.001 BufferedReader.read  <built-in>:0
            │  │  │  │  │     └─ 0.001 __build_class__  <built-in>:0
            │  │  │  │  ├─ 0.001 <module>  multiprocessing/pool.py:1
            │  │  │  │  │  └─ 0.001 <module>  multiprocessing/connection.py:1
            │  │  │  │  │     └─ 0.001 create_dynamic  <built-in>:0
            │  │  │  │  ├─ 0.001 loads  <built-in>:0
            │  │  │  │  ├─ 0.001 <module>  flake8/processor.py:1
            │  │  │  │  │  └─ 0.001 BufferedReader.__exit__  <built-in>:0
            │  │  │  │  └─ 0.001 <module>  flake8/defaults.py:1
            │  │  │  │     └─ 0.001 compile  re.py:249
            │  │  │  │        └─ 0.001 _compile  re.py:288
            │  │  │  │           └─ 0.001 compile  sre_compile.py:759
            │  │  │  │              └─ 0.001 parse  sre_parse.py:937
            │  │  │  │                 └─ 0.001 _parse_sub  sre_parse.py:435
            │  │  │  │                    └─ 0.001 _parse  sre_parse.py:493
            │  │  │  │                       └─ 0.001 _parse_sub  sre_parse.py:435
            │  │  │  │                          └─ 0.001 _parse  sre_parse.py:493
            │  │  │  └─ 0.001 loads  <built-in>:0
            │  │  ├─ 0.005 <module>  flakeheaven/_logic/_colors.py:1
            │  │  │  ├─ 0.004 <module>  colorama/__init__.py:1
            │  │  │  │  ├─ 0.003 <module>  colorama/initialise.py:1
            │  │  │  │  │  └─ 0.003 <module>  colorama/ansitowin32.py:1
            │  │  │  │  │     ├─ 0.002 <module>  colorama/winterm.py:1
            │  │  │  │  │     │  └─ 0.002 <module>  colorama/win32.py:1
            │  │  │  │  │     │     └─ 0.001 <module>  ctypes/__init__.py:1
            │  │  │  │  │     │        └─ 0.001 create_dynamic  <built-in>:0
            │  │  │  │  │     └─ 0.001 AnsiToWin32  colorama/ansitowin32.py:64
            │  │  │  │  │        └─ 0.001 compile  re.py:249
            │  │  │  │  │           └─ 0.001 _compile  re.py:288
            │  │  │  │  │              └─ 0.001 compile  sre_compile.py:759
            │  │  │  │  │                 └─ 0.001 _code  sre_compile.py:598
            │  │  │  │  │                    └─ 0.001 _compile_info  sre_compile.py:536
            │  │  │  │  │                       └─ 0.001 getwidth  sre_parse.py:174
            │  │  │  │  │                          └─ 0.001 min  <built-in>:0
            │  │  │  │  └─ 0.001 listdir  <built-in>:0
            │  │  │  └─ 0.001 compile  re.py:249
            │  │  │     └─ 0.001 _compile  re.py:288
            │  │  │        └─ 0.001 compile  sre_compile.py:759
            │  │  │           └─ 0.001 _code  sre_compile.py:598
            │  │  │              └─ 0.001 _compile  sre_compile.py:71
            │  │  │                 └─ 0.001 _compile  sre_compile.py:71
            │  │  │                    └─ 0.001 _compile  sre_compile.py:71
            │  │  │                       └─ 0.001 _compile  sre_compile.py:71
            │  │  │                          └─ 0.001 len  <built-in>:0
            │  │  ├─ 0.002 <module>  flakeheaven/_logic/_baseline.py:1
            │  │  │  ├─ 0.001 <module>  hashlib.py:1
            │  │  │  │  └─ 0.001 create_dynamic  <built-in>:0
            │  │  │  └─ 0.001 BufferedReader.read  <built-in>:0
            │  │  ├─ 0.001 BufferedReader.read  <built-in>:0
            │  │  └─ 0.001 <module>  flakeheaven/_logic/_extractors.py:1
            │  │     └─ 0.001 compile  re.py:249
            │  │        └─ 0.001 _compile  re.py:288
            │  │           └─ 0.001 compile  sre_compile.py:759
            │  │              └─ 0.001 _code  sre_compile.py:598
            │  │                 └─ 0.001 _compile  sre_compile.py:71
            │  │                    └─ 0.001 _simple  sre_compile.py:423
            │  │                       └─ 0.001 __len__  sre_parse.py:160
            │  │                          └─ 0.001 len  <built-in>:0
            │  ├─ 0.024 <module>  flakeheaven/commands/__init__.py:1
            │  │  ├─ 0.022 <module>  flakeheaven/commands/_baseline.py:1
            │  │  │  ├─ 0.012 <module>  flakeheaven/formatters/__init__.py:1
            │  │  │  │  ├─ 0.009 <module>  flakeheaven/formatters/_colored.py:1
            │  │  │  │  │  ├─ 0.002 __getattr__  pygments/lexers/__init__.py:329
            │  │  │  │  │  │  └─ 0.002 _load_lexers  pygments/lexers/__init__.py:42
            │  │  │  │  │  │     └─ 0.002 <module>  pygments/lexers/python.py:1
            │  │  │  │  │  │        ├─ 0.001 <module>  pygments/lexer.py:1
            │  │  │  │  │  │        │  └─ 0.001 BufferedReader.read  <built-in>:0
            │  │  │  │  │  │        └─ 0.001 BufferedReader.read  <built-in>:0
            │  │  │  │  │  ├─ 0.002 <module>  pygments/formatters/__init__.py:1
            │  │  │  │  │  │  ├─ 0.001 BufferedReader.read  <built-in>:0
            │  │  │  │  │  │  └─ 0.001 <module>  pygments/util.py:1
            │  │  │  │  │  │     └─ 0.001 compile  re.py:249
            │  │  │  │  │  │        └─ 0.001 _compile  re.py:288
            │  │  │  │  │  │           └─ 0.001 compile  sre_compile.py:759
            │  │  │  │  │  │              └─ 0.001 parse  sre_parse.py:937
            │  │  │  │  │  │                 └─ 0.001 _parse_sub  sre_parse.py:435
            │  │  │  │  │  │                    └─ 0.001 tell  sre_parse.py:286
            │  │  │  │  │  ├─ 0.002 <module>  pygments/lexers/__init__.py:1
            │  │  │  │  │  │  ├─ 0.001 BufferedReader.read  <built-in>:0
            │  │  │  │  │  │  └─ 0.001 [self]
            │  │  │  │  │  ├─ 0.001 __getattr__  pygments/formatters/__init__.py:139
            │  │  │  │  │  │  └─ 0.001 _load_formatters  pygments/formatters/__init__.py:36
            │  │  │  │  │  │     └─ 0.001 <module>  pygments/formatters/terminal.py:1
            │  │  │  │  │  │        └─ 0.001 <module>  pygments/formatter.py:1
            │  │  │  │  │  │           └─ 0.001 BufferedReader.read  <built-in>:0
            │  │  │  │  │  ├─ 0.001 BufferedReader.read  <built-in>:0
            │  │  │  │  │  └─ 0.001 int.from_bytes  <built-in>:0
            │  │  │  │  ├─ 0.001 BufferedReader.read  <built-in>:0
            │  │  │  │  └─ 0.001 open_code  <built-in>:0
            │  │  │  └─ 0.010 <module>  flakeheaven/_patched/__init__.py:1
            │  │  │     ├─ 0.009 <module>  flakeheaven/_patched/_app.py:1
            │  │  │     │  ├─ 0.006 <module>  flake8/main/application.py:1
            │  │  │     │  │  ├─ 0.002 <module>  flake8/options/aggregator.py:1
            │  │  │     │  │  │  └─ 0.002 <module>  flake8/options/config.py:1
            │  │  │     │  │  │     └─ 0.002 <module>  configparser.py:1
            │  │  │     │  │  │        ├─ 0.001 __build_class__  <built-in>:0
            │  │  │     │  │  │        └─ 0.001 RawConfigParser  configparser.py:560
            │  │  │     │  │  │           └─ 0.001 compile  re.py:249
            │  │  │     │  │  │              └─ 0.001 _compile  re.py:288
            │  │  │     │  │  │                 └─ 0.001 compile  sre_compile.py:759
            │  │  │     │  │  │                    └─ 0.001 parse  sre_parse.py:937
            │  │  │     │  │  │                       └─ 0.001 _parse_sub  sre_parse.py:435
            │  │  │     │  │  │                          └─ 0.001 _parse  sre_parse.py:493
            │  │  │     │  │  │                             └─ 0.001 _parse_sub  sre_parse.py:435
            │  │  │     │  │  │                                └─ 0.001 _parse  sre_parse.py:493
            │  │  │     │  │  ├─ 0.001 BufferedReader.read  <built-in>:0
            │  │  │     │  │  ├─ 0.001 <module>  flake8/main/options.py:1
            │  │  │     │  │  │  └─ 0.001 BufferedReader.read  <built-in>:0
            │  │  │     │  │  ├─ 0.001 <module>  flake8/plugins/manager.py:1
            │  │  │     │  │  └─ 0.001 <module>  flake8/style_guide.py:1
            │  │  │     │  │     └─ 0.001 isinstance  <built-in>:0
            │  │  │     │  └─ 0.003 <module>  flakeheaven/_patched/_checkers.py:1
            │  │  │     │     ├─ 0.001 __new__  typing.py:2242
            │  │  │     │     │  └─ 0.001 _make_nmtuple  typing.py:2222
            │  │  │     │     │     └─ 0.001 namedtuple  collections/__init__.py:328
            │  │  │     │     ├─ 0.001 getattr  <built-in>:0
            │  │  │     │     └─ 0.001 <module>  flakeheaven/_patched/_processor.py:1
            │  │  │     │        └─ 0.001 <module>  flakeheaven/parsers/__init__.py:1
            │  │  │     └─ 0.001 listdir  <built-in>:0
            │  │  ├─ 0.001 BufferedReader.read  <built-in>:0
            │  │  └─ 0.001 [self]
            │  ├─ 0.019 <module>  flakeheaven/_constants.py:1
            │  │  └─ 0.019 <module>  flakeheaven/_version.py:1
            │  │     ├─ 0.015 <module>  importlib/metadata/__init__.py:1
            │  │     │  ├─ 0.010 <module>  importlib/metadata/_adapters.py:1
            │  │     │  │  ├─ 0.009 <module>  email/message.py:1
            │  │     │  │  │  ├─ 0.006 <module>  email/utils.py:1
            │  │     │  │  │  │  ├─ 0.002 <module>  socket.py:1
            │  │     │  │  │  │  │  └─ 0.001 create_dynamic  <built-in>:0
            │  │     │  │  │  │  ├─ 0.002 <module>  email/charset.py:1
            │  │     │  │  │  │  ├─ 0.001 <module>  email/_parseaddr.py:1
            │  │     │  │  │  │  │  └─ 0.001 <module>  calendar.py:1
            │  │     │  │  │  │  │     └─ 0.001 __build_class__  <built-in>:0
            │  │     │  │  │  │  └─ 0.001 <module>  datetime.py:1
            │  │     │  │  │  │     └─ 0.001 _create  datetime.py:2205
            │  │     │  │  │  ├─ 0.001 BufferedReader.read  <built-in>:0
            │  │     │  │  │  └─ 0.001 stat  <built-in>:0
            │  │     │  │  └─ 0.001 listdir  <built-in>:0
            │  │     │  ├─ 0.001 <module>  zipfile.py:1
            │  │     │  │  └─ 0.001 BufferedReader.read  <built-in>:0
            │  │     │  ├─ 0.001 BufferedReader.read  <built-in>:0
            │  │     │  ├─ 0.001 [self]
            │  │     │  ├─ 0.001 <module>  importlib/metadata/_meta.py:1
            │  │     │  │  └─ 0.001 PackageMetadata  importlib/metadata/_meta.py:7
            │  │     │  │     └─ 0.001 inner  typing.py:305
            │  │     │  │        └─ 0.001 __getitem__  typing.py:400
            │  │     │  │           └─ 0.001 Union  typing.py:482
            │  │     │  │              └─ 0.001 __init__  typing.py:999
            │  │     │  └─ 0.001 <module>  pathlib.py:1
            │  │     │     └─ 0.001 _WindowsFlavour  pathlib.py:112
            │  │     ├─ 0.003 version  importlib/metadata/__init__.py:939
            │  │     │  ├─ 0.002 version  importlib/metadata/__init__.py:594
            │  │     │  │  └─ 0.002 metadata  importlib/metadata/__init__.py:567
            │  │     │  │     ├─ 0.001 message_from_string  email/__init__.py:32
            │  │     │  │     │  └─ 0.001 <module>  email/parser.py:1
            │  │     │  │     │     └─ 0.001 <module>  email/feedparser.py:1
            │  │     │  │     │        └─ 0.001 __build_class__  <built-in>:0
            │  │     │  │     └─ 0.001 read_text  importlib/metadata/__init__.py:881
            │  │     │  │        └─ 0.001 joinpath  pathlib.py:843
            │  │     │  │           └─ 0.001 _make_child  pathlib.py:613
            │  │     │  │              └─ 0.001 _parse_args  pathlib.py:567
            │  │     │  │                 └─ 0.001 parse_parts  pathlib.py:56
            │  │     │  │                    └─ 0.001 splitroot  pathlib.py:239
            │  │     │  └─ 0.001 distribution  importlib/metadata/__init__.py:913
            │  │     │     └─ 0.001 from_name  importlib/metadata/__init__.py:502
            │  │     │        └─ 0.001 <genexpr>  importlib/metadata/__init__.py:865
            │  │     │           └─ 0.001 search  importlib/metadata/__init__.py:763
            │  │     │              └─ 0.001 wrapper  importlib/metadata/_functools.py:75
            │  │     │                 └─ 0.001 lookup  importlib/metadata/__init__.py:772
            │  │     │                    └─ 0.001 __init__  importlib/metadata/__init__.py:778
            │  │     │                       └─ 0.001 joinpath  importlib/metadata/__init__.py:746
            │  │     │                          └─ 0.001 __new__  pathlib.py:955
            │  │     │                             └─ 0.001 _from_parts  pathlib.py:587
            │  │     │                                └─ 0.001 _parse_args  pathlib.py:567
            │  │     │                                   └─ 0.001 parse_parts  pathlib.py:56
            │  │     └─ 0.001 loads  <built-in>:0
            │  └─ 0.001 BufferedReader.read  <built-in>:0
            └─ 0.001 stat  <built-in>:0
```
  
</details>


