### PR TITLE
Fix/plugin flags

### DIFF
--- a/flakeheaven/_patched/_app.py
+++ b/flakeheaven/_patched/_app.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from flake8 import _EXTRA_VERBOSE, LOG as FLAKE8_LOG
 from flake8.main.application import Application
 from flake8.options.config import ConfigParser, get_local_plugins
+from flake8.options.manager import Option
 from flake8.plugins.manager import ReportFormatters
 from flake8.utils import parse_unified_diff
 
@@ -62,16 +63,56 @@ class FlakeHeavenApplication(Application):
         group.add_argument('--safe', action='store_true', help='suppress exceptions from plugins')
         self._option_manager = manager
 
-    def get_toml_config(self, path: Path = None) -> Dict[str, Any]:
+    def get_toml_config(
+        self,
+        path: Optional[Path] = None,
+        *,
+        enforce_keys_from: Dict[str, Option],
+    ) -> Dict[str, Any]:
+        """Extract config from TOML.
+
+        Args:
+            path: toml filepath. If not set, searches in cwd parents.
+            enforce_keys_from: Mapping of configuration option names to
+             :class:`~flake8.options.manager.Option` instances. It is
+             used to convert ``dashed-names`` in `toml` to
+             :class:`~flake8.options.config.ConfigParser` namespace so
+             it can be updated via its ``__dict__``. Typically, it comes
+             from either
+             :attr:`~flake8.options.config.ConfigParser.config_options`,
+             or directly from
+             :attr:`~flake8.options.manager.OptionManager.config_options_dict`.
+        """
         if path is not None:
-            return read_config(path)
-        # lookup for config from current dir up to root
-        root = Path().resolve()
-        for dir_path in chain([root], root.parents):
-            path = dir_path / 'pyproject.toml'
-            if path.exists():
-                return read_config(path)
-        return dict()
+            toml_config = read_config(path)
+        else:
+            # lookup for config from current dir up to root
+            root = Path().resolve()
+            for dir_path in chain([root], root.parents):
+                path = dir_path / 'pyproject.toml'
+                if path.exists():
+                    toml_config = read_config(path)
+                    break
+            else:
+                toml_config = {}
+
+        for name in list(toml_config.keys()):
+            try:
+                option = enforce_keys_from[name]
+                dst = option.config_name
+                if dst == name:
+                    continue
+                if dst is None:
+                    raise ValueError(
+                        f'Unable to parse `{path}`. '
+                        f'Reason: option {option}.config_name not set. '
+                        f'Maybe its not enabled as `parse_from_config`?'  # noqa: C812
+                    )
+            except KeyError:
+                continue
+
+            toml_config[dst] = toml_config.pop(name)
+        return toml_config
 
     @staticmethod
     def extract_toml_config_path(argv: List[str]) -> Tuple[Optional[Path], List[str]]:
@@ -118,12 +159,6 @@ class FlakeHeavenApplication(Application):
             _EXTRA_VERBOSE, 'CONFIG: after flakeheaven defaults:```%s```', vars(config),
         )
 
-        # patch config wtih TOML
-        # If config is explicilty passed, it will be used
-        # If config isn't specified, flakeheaven will lookup for it
-        config.__dict__.update(self.get_toml_config(self._config_path))
-        LOG.log(_EXTRA_VERBOSE, 'CONFIG: after toml update:```%s```', vars(config))
-
         # Parse CLI options and legacy flake8 configs.
         # Based on `aggregate_options`.
         config_parser = ConfigParser(
@@ -131,8 +166,18 @@ class FlakeHeavenApplication(Application):
             config_finder=config_finder,
         )
         parsed_config = config_parser.parse()
+
+        toml_config = self.get_toml_config(
+            self._config_path,
+            enforce_keys_from=config_parser.config_options,
+        )
+
+        config.__dict__.update(toml_config)
+        LOG.log(_EXTRA_VERBOSE, 'CONFIG: after toml update:```%s```', vars(config))
+
         config.extended_default_select = self.option_manager.extended_default_select.copy()
         config.extended_default_ignore = self.option_manager.extended_default_ignore.copy()
+
         for config_name, value in parsed_config.items():
             dest_name = config_name
             # If the config name is somehow different from the destination name,

--- a/tests/test_patched/test_app.py
+++ b/tests/test_patched/test_app.py
@@ -1,0 +1,99 @@
+# built-in
+from collections import defaultdict
+import json
+
+# external
+import pytest
+
+# app
+from flakeheaven._constants import NAME, VERSION
+from flakeheaven._patched import FlakeHeavenApplication
+
+
+@pytest.fixture
+def initialized_app(request, tmp_path):
+    toml_config, py_code = request.param
+
+    toml_config_file = tmp_path / 'test_config.toml'
+    toml_config_file.write_text(toml_config)
+
+    python_lintee = tmp_path / 'code.py'
+    python_lintee.write_text(py_code)
+
+    app = FlakeHeavenApplication(program=NAME, version=VERSION)
+    app.initialize([f'--config={toml_config_file}', str(python_lintee)])
+
+    yield app
+
+
+MAX_LINE_LENGTH = 4
+MAX_DOC_LENGTH = 10
+
+TOML_CONFIG_1 = f"""
+[tool.flakeheaven]
+format = "json"
+# https://pycodestyle.pycqa.org/en/latest/intro.html#configuration
+max-line-length ={MAX_LINE_LENGTH}
+max_doc_length = {MAX_DOC_LENGTH}
+
+[tool.flakeheaven.plugins]
+pycodestyle = ["+E501", "+W505"]
+
+"""
+
+TOML_CONFIG_2 = f"""
+[tool.flakeheaven]
+format = "json"
+# https://pycodestyle.pycqa.org/en/latest/intro.html#configuration
+max_line_length ={MAX_LINE_LENGTH}
+max-doc-length = {MAX_DOC_LENGTH}
+
+[tool.flakeheaven.plugins]
+pycodestyle = ["+E501", "+W505"]
+
+"""
+
+PY_CODE = """
+a=0
+'''e501'''
+
+b=5
+'''both errors here'''
+"""
+
+EXPECTED = json.dumps({
+    3: {
+        'E501': f'line too long (10 > {MAX_LINE_LENGTH} characters)',
+    },
+    6: {
+        'E501': f'line too long (22 > {MAX_LINE_LENGTH} characters)',
+        'W505': f'doc line too long (22 > {MAX_DOC_LENGTH} characters)',
+    },
+}, sort_keys=True)
+
+
+@pytest.mark.parametrize(
+    'initialized_app',
+    [
+        [TOML_CONFIG_1, PY_CODE],
+        [TOML_CONFIG_2, PY_CODE],
+    ],
+    indirect=True,
+)
+def test_plugin_flags(initialized_app, capsys):
+
+    assert initialized_app.options.max_line_length == MAX_LINE_LENGTH, '`max_line_length` incorrectly set from toml'
+    assert initialized_app.options.max_doc_length == MAX_DOC_LENGTH, '`max_doc_length` incorrectly set from toml'
+
+    initialized_app.run_checks()
+    out0 = capsys.readouterr().out
+    initialized_app.report()
+    captured = capsys.readouterr().out.replace(out0, '')
+
+    found = defaultdict(dict)
+    for c in captured.splitlines():
+        report = json.loads(c)
+        found[report['line']][report['code']] = report['description']
+
+    found_json = json.dumps(found, sort_keys=True)
+    assert found_json == EXPECTED, f'found:`{found_json}` but expected:`{EXPECTED}`'


### PR DESCRIPTION
DRAFT:
*  [x] wait for #107 to be merged
*  [x] rebase from main

This fix allows to use the same names in toml configuration files
as those from flake8.

Before this, values in the main `flakeheaven` section of the config
file required using the configuration name (as in
`flake8.options.manager.Option.configuration_name`). For example,
setting `max-doc-length` (with hyphens) had no effect on `W505` when
using flakeheaven, but worked as intened in plain flake8 using
`tox.ini`.

With this fix applied, configurations can use the same names from
`.ini`-style in the `.toml` config.

* Added test validating pycodestyle using max-line-length

related #103
related #78
fixes #105
