### PR TITLE
fix: disable plugin execution when '-*' is used as exception

### DIFF
--- a/flakeheaven/_patched/_checkers.py
+++ b/flakeheaven/_patched/_checkers.py
@@ -140,11 +140,15 @@ class FlakeHeavenCheckersManager(Manager):
             exceptions=self.options.exceptions,
         )
         if exceptions:
-            rules = rules.copy()
-            rules += get_plugin_rules(
+            exception_rules = get_plugin_rules(
                 plugin_name=plugin_name,
                 plugins=exceptions,
             )
+            if '-*' in exception_rules:
+                rules = exception_rules
+            else:
+                rules = rules.copy()
+                rules += exception_rules
         return rules
 
     def is_path_excluded(self, filename: str) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+# external
+import pytest
+
+# project
+from flakeheaven._constants import NAME, VERSION
+from flakeheaven._patched import FlakeHeavenApplication
+
+
+@pytest.fixture
+def initialized_app(request, tmp_path, monkeypatch):
+    toml_config, py_code, *init_args = request.param
+
+    config_name = 'test_config.toml'
+    code_name = 'testcode.py'
+    with monkeypatch.context() as m:
+        m.chdir(tmp_path)
+        toml_config_file = tmp_path / config_name
+        toml_config_file.write_text(toml_config)
+
+        python_lintee = tmp_path / code_name
+        python_lintee.write_text(py_code)
+
+        app = FlakeHeavenApplication(program=NAME, version=VERSION)
+        app.initialize([f'--config={config_name}', code_name, *init_args])
+        yield app

--- a/tests/test_commands/test_config.py
+++ b/tests/test_commands/test_config.py
@@ -1,14 +1,15 @@
 # built-in
+import subprocess as sp
 from pathlib import Path
 from shlex import split
-import subprocess as sp
 from typing import Optional
 
 # external
 import pytest
 
-# app
+# project
 from flakeheaven.commands._config import get_config
+
 
 HELP = """\
 usage: flakeheaven [-h] [--plugins-only] [--flake8-logs] [-v]

--- a/tests/test_logic/test_plugin.py
+++ b/tests/test_logic/test_plugin.py
@@ -1,9 +1,10 @@
 # built-in
 from pathlib import Path
 
-# project
+# external
 import pytest
 
+# project
 from flakeheaven._logic import get_exceptions
 
 

--- a/tests/test_logic/test_snapshot.py
+++ b/tests/test_logic/test_snapshot.py
@@ -1,9 +1,9 @@
 # built-in
 import importlib
 import os
-from pathlib import Path
 import subprocess as sp
 import time
+from pathlib import Path
 from typing import Generator
 
 # external
@@ -11,7 +11,7 @@ import pytest
 
 # project
 import flakeheaven._logic._snapshot
-from flakeheaven._logic._snapshot import prepare_cache, CACHE_PATH
+from flakeheaven._logic._snapshot import CACHE_PATH, prepare_cache
 
 
 @pytest.mark.parametrize(

--- a/tests/test_logic/test_snapshot.py
+++ b/tests/test_logic/test_snapshot.py
@@ -116,11 +116,11 @@ def test_prepare_cache(monkeypatch, tmp_path: Path):
     # enforce toml config, code and preexisting cache
     cache_path = tmp_path / 'cache'
     (tmp_path / 'pyproject.toml').write_text(PYPROJECT_TOML)
-    (tmp_path / 'code.py').write_text(PY_CODE)
+    (tmp_path / 'testcode.py').write_text(PY_CODE)
     monkeypatch.setenv('FLAKEHEAVEN_CACHE_TIMEOUT', '0')
     monkeypatch.setenv('FLAKEHEAVEN_CACHE', str(cache_path))
 
-    sp.run(['flakeheaven', 'lint', 'code.py'])
+    sp.run(['flakeheaven', 'lint', 'testcode.py'])
 
     importlib.reload(flakeheaven._logic._snapshot)
 

--- a/tests/test_patched/test_app.py
+++ b/tests/test_patched/test_app.py
@@ -6,24 +6,8 @@ from collections import defaultdict
 import pytest
 
 # project
-from flakeheaven._constants import NAME, VERSION, ExitCode
-from flakeheaven._patched import FlakeHeavenApplication
-
-
-@pytest.fixture
-def initialized_app(request, tmp_path):
-    toml_config, py_code, *init_args = request.param
-
-    toml_config_file = tmp_path / 'test_config.toml'
-    toml_config_file.write_text(toml_config)
-
-    python_lintee = tmp_path / 'code.py'
-    python_lintee.write_text(py_code)
-
-    app = FlakeHeavenApplication(program=NAME, version=VERSION)
-    app.initialize([f'--config={toml_config_file}', str(python_lintee), *init_args])
-
-    yield app
+import flakeheaven._patched._checkers as checkers
+from flakeheaven._constants import ExitCode
 
 
 MAX_LINE_LENGTH = 4

--- a/tests/test_patched/test_app.py
+++ b/tests/test_patched/test_app.py
@@ -1,11 +1,11 @@
 # built-in
-from collections import defaultdict
 import json
+from collections import defaultdict
 
 # external
 import pytest
-import flakeheaven._patched._checkers as checkers
-# app
+
+# project
 from flakeheaven._constants import NAME, VERSION, ExitCode
 from flakeheaven._patched import FlakeHeavenApplication
 

--- a/tests/test_patched/test_checkers.py
+++ b/tests/test_patched/test_checkers.py
@@ -1,4 +1,5 @@
 # built-in
+from pathlib import Path
 from unittest import mock
 
 # external
@@ -52,3 +53,76 @@ def test_catches_exception_on_invalid_syntax(tmp_path):
     assert len(fchecker.results) == 1
     assert fchecker.results[0].error_code == 'E999'
     assert fchecker.results[0].text.startswith('SyntaxError: invalid syntax')
+
+
+TOML_EXCEPTION_OVERRIDE = """
+[tool.flakeheaven.plugins]
+pycodestyle = ["+*"]
+
+[tool.flakeheaven.exceptions."testcode.py"]
+pycodestyle = ["-*", "+E401"]
+"""
+
+TOML_GLOB_DISABLE = """
+[tool.flakeheaven.plugins]
+pycodestyle = ["+*"]
+
+[tool.flakeheaven.exceptions."testcode.py"]
+pycodestyle = ["-*"]
+"""
+
+
+@pytest.fixture
+def change_test_dir(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    yield tmp_path
+
+
+@pytest.mark.parametrize(
+    'initialized_app',
+    [
+        [TOML_EXCEPTION_OVERRIDE, 'asdf=', str(False)],
+        [TOML_GLOB_DISABLE, 'asdf=', str(True)],
+    ],
+    indirect=True,
+)
+def test_exception_disable(initialized_app):
+    """Adding '-*' to exception disables a check partially/completely ."""
+    code_py = Path(initialized_app.args[0]).name
+
+    # Define wether any check should be performed using pytest
+    # parametrize last arg (as seen from
+    # flake8.main.application.Application).
+    should_skip = {
+        str(True): True,
+        str(False): False,
+    }[initialized_app.args.pop()]
+
+    manager = initialized_app.file_checker_manager
+    manager.make_checkers()
+    checkers = manager.checkers
+
+    if should_skip:
+        # there should be no checkers activated
+        assert len(checkers) == 0
+        return
+
+    # only a single checker should be active
+    assert len(checkers) == 1
+    checker = checkers[0]
+
+    # if we partially removed pycodestyle, it should not be checked!
+    for group in checker.checks.values():
+        for plugin in group:
+            plugin_name = plugin['plugin_name']
+            if plugin['plugin_name'] != 'pycodestyle':
+                continue
+            assert manager._get_rules(plugin_name, filename='non-existent-file.py') == ['+*']
+            rules = manager._get_rules(plugin_name, filename=code_py)
+            assert rules == ['-*', '+E401']
+    path, results, _ = checker.run_checks()
+    assert Path(path).name == code_py
+    assert len(results) == 1
+    result = results[0]
+    # it should raise syntaxerror on `asdf=`
+    assert result.error_code == 'E999'

--- a/tests/test_patched/test_checkers.py
+++ b/tests/test_patched/test_checkers.py
@@ -1,6 +1,9 @@
 # built-in
 from unittest import mock
 
+# external
+import pytest
+
 # project
 from flakeheaven._patched._checkers import FlakeHeavenFileChecker
 

--- a/tests/test_plugins/test_pylint.py
+++ b/tests/test_plugins/test_pylint.py
@@ -5,26 +5,6 @@ from collections import defaultdict
 # external
 import pytest
 
-# app
-from flakeheaven._constants import NAME, VERSION
-from flakeheaven._patched import FlakeHeavenApplication
-
-
-@pytest.fixture
-def initialized_app(request, tmp_path):
-    toml_config, py_code = request.param
-
-    toml_config_file = tmp_path / 'test_config.toml'
-    toml_config_file.write_text(toml_config)
-
-    python_lintee = tmp_path / 'code.py'
-    python_lintee.write_text(py_code)
-
-    app = FlakeHeavenApplication(program=NAME, version=VERSION)
-    app.initialize([f'--config={toml_config_file}', str(python_lintee)])
-
-    yield app
-
 
 MAX_LINE_LENGTH = 4
 

--- a/tests/test_plugins/test_pylint.py
+++ b/tests/test_plugins/test_pylint.py
@@ -1,6 +1,6 @@
 # built-in
-from collections import defaultdict
 import json
+from collections import defaultdict
 
 # external
 import pytest


### PR DESCRIPTION
fix: disable plugin execution when '-*' is used as exception

When there is an exception targeting a whole plugin (eg `pycodestyle = ['-*']`), and the plugin is activated globally (eg
`pycodestyle = ['+*']`), the plugin would be executed anyway.

This is  because the `_should_process` method checks for `not rules or set(rules) == {'-*'}`.

This change replaces the check with the following procedure:

If `'-*'` is a valid exception, the plugin configuration equals the respective exception (minus the `'-*'` glob, of course).
Otherwise, the exception config is appended to the plugin config list.

An implication of this is that if an exception contains only `-*`, and it matches the current file, `_should_process` returns
`False`, and the plugin check is skipped from execution entirely.

fixes #149