### PR TITLE
Use `types_or` in pre-commit hook definition

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,6 +3,6 @@
     description: '`flakeheaven` is a `flake8` wrapper to make a nice, legacy-friendly, configurable command-line utility for enforcing style consistency across Python projects.'
     entry: flakeheaven lint
     language: python
-    types: [file, text]
-    files: \.(ipynb|md|py|rst|yaml|yml)$
+    types_or: [python, jupyter, markdown, rst, yaml]
     require_serial: true
+    minimum_pre_commit_version: 2.9.0


### PR DESCRIPTION
### Advantadges

- Specifying `files` in a directory does not silently drop file types and is easy to filter by directory. For example, if I define `files: ^src/` the files against to run will be only the subset inside `types_or`, I don't need to specify all extensions in `files` regexp.
- Files without canonical extensions will be also linted. For example, `.yamllint` files will be checked as pre-commit's [identify](https://github.com/pre-commit/identify) will discover that [is a YAML file](https://github.com/pre-commit/identify/blob/4e27a619e003a14f5b57b87c53da75794b44dc66/identify/extensions.py#L306).

Note that I added `2.9.0` as `minimum_pre_commit_version` because `types_or` was added in that version.