### PR TITLE
flakeheaven missed: return 0 when there are no missing plugins

### DIFF
--- a/flakeheaven/commands/_missed.py
+++ b/flakeheaven/commands/_missed.py
@@ -20,6 +20,9 @@ def missed_command(argv) -> CommandResult:
     except NoPlugins:
         return ExitCode.NO_PLUGINS_INSTALLED, 'no plugins installed'
 
+    if not missing:
+        return ExitCode.OK, ''
+
     for pattern in missing:
         print(pattern)
 


### PR DESCRIPTION
Currently flakeheaven always fails even when there are no missing plugins.