### PR TITLE
feat: Change default cache dir to workdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pip-wheel-metadata/
 .vscode/launch.json
 docs/_build/
 docs/apidoc/
+.idea/

--- a/docs/config.md
+++ b/docs/config.md
@@ -81,6 +81,17 @@ format='colored'
 max_line_length=90
 ```
 
+## Cache settings
+
+FlakeHeaven caches results. Cache invalidates after 24 hours or if the configuration was changed.
+Default cache directory is `.flakeheaven_cache` in your working directory.
+
+It can be changed by environment variable `FLAKEHEAVEN_CACHE`.
+Also, you can change threshold by variable `FLAKEHEAVEN_CACHE_TIMEOUT`.
+```bash
+FLAKEHEAVEN_CACHE=/tmp/mydir FLAKEHEAVEN_CACHE_TIMEOUT=0 flakeheaven lint
+```
+
 ## Additional settings
 
 FlakeHeaven provides a few additional options that aren't supported by the original flake8. They can be specified as everything else, in config or as CLI flags.

--- a/tests/test_logic/test_snapshot.py
+++ b/tests/test_logic/test_snapshot.py
@@ -126,3 +126,19 @@ def test_prepare_cache(monkeypatch, tmp_path: Path):
 
     prepare_cache(path=LiarPath(cache_path))
     prepare_cache(path=RemoverPath(cache_path))
+
+
+def test_default_cache_dir(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv('FLAKEHEAVEN_CACHE_TIMEOUT', '0')
+
+    expected_cache_path = tmp_path / '.flakeheaven_cache'
+
+    (tmp_path / 'pyproject.toml').write_text(PYPROJECT_TOML)
+    (tmp_path / 'testcode.py').write_text(PY_CODE)
+
+    sp.run(['flakeheaven', 'lint', 'testcode.py'])
+
+    p = Path(expected_cache_path).resolve()
+    assert p.exists()
+    assert len(list(p.glob('*.json'))) == 1


### PR DESCRIPTION
- Change default cache directory from Home to Workdir 
- Add test for default cache directory
- Add documentation about cache settings to config section
- Add PyCharm `.idea/` directory to  `.gitignore`
- Add `pytest-clarity` to dev dependencies to make `assert` diffs more friendly

Closes #171 